### PR TITLE
Add WorkflowImplementationOptions.setLocalActivityOptions (#975)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.github.sherter.google-java-format' version '0.9' apply false
     id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'com.palantir.git-version' version '0.12.3' apply false
+    id 'com.palantir.git-version' version '0.13.0' apply false
     id 'de.marcphilipp.nexus-publish' version '0.4.0' apply false
 }
 

--- a/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkflowImplementationOptionsExt.kt
+++ b/temporal-kotlin/src/main/kotlin/io/temporal/worker/WorkflowImplementationOptionsExt.kt
@@ -20,6 +20,7 @@
 package io.temporal.worker
 
 import io.temporal.activity.ActivityOptions
+import io.temporal.activity.LocalActivityOptions
 import io.temporal.common.metadata.activityName
 import io.temporal.kotlin.TemporalDsl
 
@@ -69,4 +70,43 @@ inline fun @TemporalDsl WorkflowImplementationOptions.Builder.setDefaultActivity
   defaultActivityOptions: @TemporalDsl ActivityOptions.Builder.() -> Unit
 ) {
   setDefaultActivityOptions(ActivityOptions(defaultActivityOptions))
+}
+
+/**
+ * Set individual Local Activity options per `activityType`.
+ *
+ * The [activityName] method could be used resolve activity method references to activity names:
+ *
+ * ```kotlin
+ * val options = WorkflowImplementationOptions {
+ *   // ...
+ *   setLocalActivityOptions(
+ *     localActivityName(Activity1::method1) to LocalActivityOptions {
+ *       // options for local activity method1
+ *     },
+ *     localActivityName(Activity2::method2) to LocalActivityOptions {
+ *       // options for local activity method2
+ *     },
+ *   )
+ * }
+ * ```
+ *
+ * @param localActivityOptions map from activityType to [LocalActivityOptions]
+ * @see WorkflowImplementationOptions.Builder.setLocalActivityOptions
+ * @see WorkflowImplementationOptions.getLocalActivityOptions
+ */
+fun WorkflowImplementationOptions.Builder.setLocalActivityOptions(
+  vararg localActivityOptions: Pair<String, LocalActivityOptions>
+) {
+  setLocalActivityOptions(localActivityOptions.toMap())
+}
+
+/**
+ * @see WorkflowImplementationOptions.Builder.setDefaultLocalActivityOptions
+ * @see WorkflowImplementationOptions.getDefaultLocalActivityOptions
+ */
+inline fun @TemporalDsl WorkflowImplementationOptions.Builder.setDefaultLocalActivityOptions(
+  defaultLocalActivityOptions: @TemporalDsl LocalActivityOptions.Builder.() -> Unit
+) {
+  setDefaultLocalActivityOptions(LocalActivityOptions(defaultLocalActivityOptions))
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContext.java
@@ -261,5 +261,9 @@ public interface ReplayWorkflowContext extends ReplayAware {
   /** Updates or inserts search attributes used to index workflows. */
   void upsertSearchAttributes(SearchAttributes searchAttributes);
 
+  /** @return workflow retry attempt. default is 1 */
   int getAttempt();
+
+  /** @return workflow cron schedule */
+  String getCronSchedule();
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/ReplayWorkflowContextImpl.java
@@ -341,4 +341,9 @@ final class ReplayWorkflowContextImpl implements ReplayWorkflowContext {
   public int getAttempt() {
     return workflowContext.getAttempt();
   }
+
+  @Override
+  public String getCronSchedule() {
+    return workflowContext.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/replay/WorkflowContext.java
@@ -192,4 +192,8 @@ final class WorkflowContext {
     }
     this.searchAttributes.putAllIndexedFields(searchAttributes.getIndexedFieldsMap());
   }
+
+  public String getCronSchedule() {
+    return startedAttributes.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowContext.java
@@ -101,6 +101,8 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
 
   private ActivityOptions defaultActivityOptions = null;
   private Map<String, ActivityOptions> activityOptionsMap = new HashMap<>();
+  private LocalActivityOptions defaultLocalActivityOptions = null;
+  private Map<String, LocalActivityOptions> localActivityOptionsMap = new HashMap<>();
 
   public SyncWorkflowContext(
       ReplayWorkflowContext context,
@@ -128,6 +130,9 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     if (workflowImplementationOptions != null) {
       this.defaultActivityOptions = workflowImplementationOptions.getDefaultActivityOptions();
       this.activityOptionsMap = workflowImplementationOptions.getActivityOptions();
+      this.defaultLocalActivityOptions =
+          workflowImplementationOptions.getDefaultLocalActivityOptions();
+      this.localActivityOptionsMap = workflowImplementationOptions.getLocalActivityOptions();
     }
     // initial values for headInboundInterceptor and headOutboundInterceptor until they initialized
     // with actual interceptors through #initHeadInboundCallsInterceptor and
@@ -176,6 +181,14 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     return activityOptionsMap;
   }
 
+  public LocalActivityOptions getDefaultLocalActivityOptions() {
+    return defaultLocalActivityOptions;
+  }
+
+  public Map<String, LocalActivityOptions> getLocalActivityOptions() {
+    return localActivityOptionsMap;
+  }
+
   public void setDefaultActivityOptions(ActivityOptions defaultActivityOptions) {
     this.defaultActivityOptions =
         (this.defaultActivityOptions == null)
@@ -195,6 +208,29 @@ final class SyncWorkflowContext implements WorkflowOutboundCallsInterceptor {
     activityMethodOptions.forEach(
         (key, value) ->
             this.activityOptionsMap.merge(
+                key, value, (o1, o2) -> o1.toBuilder().mergeActivityOptions(o2).build()));
+  }
+
+  public void setDefaultLocalActivityOptions(LocalActivityOptions defaultLocalActivityOptions) {
+    this.defaultLocalActivityOptions =
+        (this.defaultLocalActivityOptions == null)
+            ? defaultLocalActivityOptions
+            : this.defaultLocalActivityOptions
+                .toBuilder()
+                .mergeActivityOptions(defaultLocalActivityOptions)
+                .build();
+  }
+
+  public void setLocalActivityOptions(
+      Map<String, LocalActivityOptions> localActivityMethodOptions) {
+    Objects.requireNonNull(localActivityMethodOptions);
+    if (this.localActivityOptionsMap == null) {
+      this.localActivityOptionsMap = new HashMap<>(localActivityMethodOptions);
+      return;
+    }
+    localActivityMethodOptions.forEach(
+        (key, value) ->
+            this.localActivityOptionsMap.merge(
                 key, value, (o1, o2) -> o1.toBuilder().mergeActivityOptions(o2).build()));
   }
 

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/SyncWorkflowWorker.java
@@ -115,7 +115,7 @@ public class SyncWorkflowWorker
 
     workflowWorker =
         new WorkflowWorker(
-            service, namespace, taskQueue, singleWorkerOptions, taskHandler, stickyTaskQueueName);
+            service, namespace, taskQueue, stickyTaskQueueName, singleWorkerOptions, taskHandler);
 
     // Exists to support Worker#replayWorkflowExecution functionality.
     // This handler has to be non-sticky to avoid evicting actual executions from the cache

--- a/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/sync/WorkflowInfoImpl.java
@@ -104,4 +104,9 @@ final class WorkflowInfoImpl implements WorkflowInfo {
   public int getAttempt() {
     return context.getAttempt();
   }
+
+  @Override
+  public String getCronSchedule() {
+    return context.getCronSchedule();
+  }
 }

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/ActivityPollTask.java
@@ -34,6 +34,7 @@ import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
 import java.util.concurrent.Semaphore;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,27 +44,26 @@ final class ActivityPollTask implements Poller.PollTask<ActivityTask> {
   private final WorkflowServiceStubs service;
   private final String namespace;
   private final String taskQueue;
-  private final Scope metricsScope;
   private final String identity;
   private final double activitiesPerSecond;
   private final Semaphore pollSemaphore;
+  private final Scope metricsScope;
 
   public ActivityPollTask(
-      WorkflowServiceStubs service,
-      String namespace,
-      String taskQueue,
-      Scope metricsScope,
-      String identity,
+      @Nonnull WorkflowServiceStubs service,
+      @Nonnull String namespace,
+      @Nonnull String taskQueue,
+      @Nonnull String identity,
       double activitiesPerSecond,
-      int workerTaskSlots) {
-
+      int workerTaskSlots,
+      @Nonnull Scope metricsScope) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.metricsScope = Objects.requireNonNull(metricsScope);
     this.identity = Objects.requireNonNull(identity);
     this.activitiesPerSecond = activitiesPerSecond;
     this.pollSemaphore = new Semaphore(workerTaskSlots);
+    this.metricsScope = Objects.requireNonNull(metricsScope);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTask.java
@@ -31,6 +31,8 @@ import io.temporal.internal.common.ProtobufTimeUtils;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.worker.MetricsType;
 import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,23 +42,23 @@ final class WorkflowPollTask implements Poller.PollTask<PollWorkflowTaskQueueRes
   private final WorkflowServiceStubs service;
   private final String namespace;
   private final String taskQueue;
-  private final Scope metricsScope;
   private final String identity;
   private final String binaryChecksum;
+  private final Scope metricsScope;
 
   WorkflowPollTask(
-      WorkflowServiceStubs service,
-      String namespace,
-      String taskQueue,
-      Scope metricsScope,
-      String identity,
-      String binaryChecksum) {
+      @Nonnull WorkflowServiceStubs service,
+      @Nonnull String namespace,
+      @Nonnull String taskQueue,
+      @Nonnull String identity,
+      @Nullable String binaryChecksum,
+      @Nonnull Scope metricsScope) {
     this.service = Objects.requireNonNull(service);
     this.namespace = Objects.requireNonNull(namespace);
     this.taskQueue = Objects.requireNonNull(taskQueue);
-    this.metricsScope = Objects.requireNonNull(metricsScope);
     this.identity = Objects.requireNonNull(identity);
     this.binaryChecksum = binaryChecksum;
+    this.metricsScope = Objects.requireNonNull(metricsScope);
   }
 
   @Override

--- a/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTaskFactory.java
+++ b/temporal-sdk/src/main/java/io/temporal/internal/worker/WorkflowPollTaskFactory.java
@@ -53,6 +53,6 @@ public class WorkflowPollTaskFactory
   @Override
   public Poller.PollTask<PollWorkflowTaskQueueResponse> get() {
     return new WorkflowPollTask(
-        service, namespace, taskQueue, metricScope, identity, binaryChecksum);
+        service, namespace, taskQueue, identity, binaryChecksum, metricScope);
   }
 }

--- a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java
@@ -68,10 +68,6 @@ public class MetricsType {
   public static final String WORKFLOW_TASK_HEARTBEAT_COUNTER =
       TEMPORAL_METRICS_PREFIX + "workflow_task_heartbeat";
 
-  // gauge
-  public static final String WORKFLOW_TASK_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "workflow_task_active_executor_thread_count";
-
   //
   // Activity
   //
@@ -93,10 +89,6 @@ public class MetricsType {
   @Deprecated
   public static final String ACTIVITY_CANCELED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "activity_canceled";
-
-  // gauge
-  public static final String ACTIVITY_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "activity_active_executor_thread_count";
 
   //
   // Local Activity
@@ -123,13 +115,12 @@ public class MetricsType {
   public static final String LOCAL_ACTIVITY_FAILED_COUNTER =
       TEMPORAL_METRICS_PREFIX + "local_activity_failed";
 
-  // gauge
-  public static final String LOCAL_ACTIVITY_ACTIVE_EXECUTOR_THREAD_COUNT =
-      TEMPORAL_METRICS_PREFIX + "local_activity_active_executor_thread_count";
-
   // Worker internals, tagged with worker_type
   public static final String WORKER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "worker_start";
   public static final String POLLER_START_COUNTER = TEMPORAL_METRICS_PREFIX + "poller_start";
+  // gauge
+  public static final String WORKER_TASK_SLOTS_AVAILABLE =
+      TEMPORAL_METRICS_PREFIX + "worker_task_slots_available";
 
   //
   // Worker Factory

--- a/temporal-sdk/src/main/java/io/temporal/worker/WorkerMetricsTag.java
+++ b/temporal-sdk/src/main/java/io/temporal/worker/WorkerMetricsTag.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.worker;
+
+import io.temporal.serviceclient.MetricsTag;
+
+public class WorkerMetricsTag {
+  public enum WorkerType implements MetricsTag.TagValue {
+    WORKFLOW_WORKER("WorkflowWorker"),
+    ACTIVITY_WORKER("ActivityWorker"),
+    LOCAL_ACTIVITY_WORKER("LocalActivityWorker");
+
+    WorkerType(String value) {
+      this.value = value;
+    }
+
+    private final String value;
+
+    @Override
+    public String getTag() {
+      return MetricsTag.WORKER_TYPE;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+}

--- a/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/Workflow.java
@@ -79,6 +79,16 @@ public final class Workflow {
     WorkflowInternal.setActivityOptions(activityMethodOptions);
   }
 
+  public static void setDefaultLocalActivityOptions(
+      LocalActivityOptions defaultLocalActivityOptions) {
+    WorkflowInternal.setDefaultLocalActivityOptions(defaultLocalActivityOptions);
+  }
+
+  public static void setLocalActivityOptions(
+      Map<String, LocalActivityOptions> localActivityMethodOptions) {
+    WorkflowInternal.setLocalActivityOptions(localActivityMethodOptions);
+  }
+
   /**
    * Creates client stub to activities that implement given interface. `
    *

--- a/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
+++ b/temporal-sdk/src/main/java/io/temporal/workflow/WorkflowInfo.java
@@ -54,4 +54,6 @@ public interface WorkflowInfo {
   Optional<String> getParentRunId();
 
   int getAttempt();
+
+  String getCronSchedule();
 }

--- a/temporal-sdk/src/test/java/io/temporal/activity/ActivityTestOptions.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/ActivityTestOptions.java
@@ -45,4 +45,23 @@ public class ActivityTestOptions {
         .setContextPropagators(null)
         .build();
   }
+
+  public static LocalActivityOptions newLocalActivityOptions1() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofDays(1))
+        .setStartToCloseTimeout(Duration.ofSeconds(2))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(1).build())
+        .setLocalRetryThreshold(Duration.ofSeconds(1))
+        .setDoNotIncludeArgumentsIntoMarker(true)
+        .build();
+  }
+
+  public static LocalActivityOptions newLocalActivityOptions2() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofDays(3))
+        .setStartToCloseTimeout(Duration.ofSeconds(3))
+        .setRetryOptions(RetryOptions.newBuilder().setMaximumAttempts(2).build())
+        .setLocalRetryThreshold(Duration.ofSeconds(3))
+        .build();
+  }
 }

--- a/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/DefaultActivityOptionsSetOnWorkflowTest.java
@@ -56,6 +56,28 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
         }
       };
 
+  // local activity options
+  private static final LocalActivityOptions localActivityWorkflowOps =
+      ActivityTestOptions.newLocalActivityOptions1();
+  private static final LocalActivityOptions localActivityWorkerOps =
+      ActivityTestOptions.newLocalActivityOptions2();
+  private static final LocalActivityOptions localActivity2Ops =
+      SDKTestOptions.newLocalActivityOptions20sScheduleToClose();
+  private static final Map<String, LocalActivityOptions> localActivity2options =
+      new HashMap<String, LocalActivityOptions>() {
+        {
+          put("LocalActivity2", localActivity2Ops);
+        }
+      };
+  private static final Map<String, LocalActivityOptions> defaultLocalActivity2options =
+      new HashMap<String, LocalActivityOptions>() {
+        {
+          put(
+              "LocalActivity2",
+              LocalActivityOptions.newBuilder().setDoNotIncludeArgumentsIntoMarker(false).build());
+        }
+      };
+
   @Rule
   public SDKTestWorkflowRule testWorkflowRule =
       SDKTestWorkflowRule.newBuilder()
@@ -63,9 +85,11 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
               WorkflowImplementationOptions.newBuilder()
                   .setDefaultActivityOptions(workerOps)
                   .setActivityOptions(activity2options)
+                  .setDefaultLocalActivityOptions(localActivityWorkerOps)
+                  .setLocalActivityOptions(localActivity2options)
                   .build(),
               TestSetDefaultActivityOptionsWorkflowImpl.class)
-          .setActivityImplementations(new TestActivityImpl())
+          .setActivityImplementations(new TestActivityImpl(), new LocalActivityTestImpl())
           .build();
 
   @Test
@@ -96,15 +120,49 @@ public class DefaultActivityOptionsSetOnWorkflowTest {
     assertEquals(workflowOps.getStartToCloseTimeout(), activity2Values.get("StartToCloseTimeout"));
   }
 
+  @Test
+  public void testSetLocalActivityWorkflowImplementationOptions() {
+    TestWorkflowReturnMap workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                TestWorkflowReturnMap.class,
+                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+    Map<String, Map<String, Duration>> result = workflowStub.execute();
+
+    // Check that local activity1 has default workerOptions options that were partially overwritten
+    // with workflow.
+    Map<String, Duration> localActivity1Values = result.get("LocalActivity1");
+    assertEquals(
+        localActivityWorkflowOps.getScheduleToCloseTimeout(),
+        localActivity1Values.get("ScheduleToCloseTimeout"));
+    assertEquals(
+        localActivityWorkflowOps.getStartToCloseTimeout(),
+        localActivity1Values.get("StartToCloseTimeout"));
+    // Check that default options for local activity2 were overwritten.
+    Map<String, Duration> localActivity2Values = result.get("LocalActivity2");
+    assertEquals(
+        localActivity2Ops.getScheduleToCloseTimeout(),
+        localActivity2Values.get("ScheduleToCloseTimeout"));
+    assertEquals(
+        localActivityWorkflowOps.getStartToCloseTimeout(),
+        localActivity2Values.get("StartToCloseTimeout"));
+  }
+
   public static class TestSetDefaultActivityOptionsWorkflowImpl implements TestWorkflowReturnMap {
     @Override
     public Map<String, Map<String, Duration>> execute() {
       Workflow.setDefaultActivityOptions(workflowOps);
       Workflow.setActivityOptions(defaultActivity2options);
+      Workflow.setDefaultLocalActivityOptions(localActivityWorkflowOps);
+      Workflow.setLocalActivityOptions(defaultLocalActivity2options);
       Map<String, Map<String, Duration>> result = new HashMap<>();
       TestActivity activities = Workflow.newActivityStub(TestActivity.class);
+      LocalActivityTest localActivities = Workflow.newLocalActivityStub(LocalActivityTest.class);
       result.put("Activity1", activities.activity1());
       result.put("Activity2", activities.activity2());
+      result.put("LocalActivity1", localActivities.localActivity1());
+      result.put("LocalActivity2", localActivities.localActivity2());
       return result;
     }
   }

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityMethodOptionsTest.java
@@ -23,7 +23,6 @@ import io.temporal.common.RetryOptions;
 import io.temporal.testing.TestActivityEnvironment;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +52,7 @@ public class LocalActivityMethodOptionsTest {
   private static final Map<String, LocalActivityOptions> perMethodOptionsMap =
       new HashMap<String, LocalActivityOptions>() {
         {
-          put("Method1", methodOps2);
+          put("LocalActivity1", methodOps2);
         }
       };
   private TestActivityEnvironment testEnv;
@@ -83,61 +82,22 @@ public class LocalActivityMethodOptionsTest {
 
   @Test
   public void testLocalActivityMethodOptions() {
-    testEnv.registerActivitiesImplementations(new ActivityImpl());
-    TestActivity localActivity =
-        testEnv.newLocalActivityStub(TestActivity.class, defaultOps, perMethodOptionsMap);
+    testEnv.registerActivitiesImplementations(new LocalActivityTestImpl());
+    LocalActivityTest localActivity =
+        testEnv.newLocalActivityStub(LocalActivityTest.class, defaultOps, perMethodOptionsMap);
 
     // Check that options for method1 were merged.
-    Map<String, Duration> method1OpsValues = localActivity.method1();
+    Map<String, Duration> method1OpsValues = localActivity.localActivity1();
     Assert.assertEquals(
         defaultOps.getScheduleToCloseTimeout(), method1OpsValues.get("ScheduleToCloseTimeout"));
     Assert.assertEquals(
         methodOps2.getStartToCloseTimeout(), method1OpsValues.get("StartToCloseTimeout"));
 
     // Check that options for method2 were default.
-    Map<String, Duration> method2OpsValues = localActivity.method2();
+    Map<String, Duration> method2OpsValues = localActivity.localActivity2();
     Assert.assertEquals(
         defaultOps.getScheduleToCloseTimeout(), method2OpsValues.get("ScheduleToCloseTimeout"));
     Assert.assertEquals(
         defaultOps.getStartToCloseTimeout(), method2OpsValues.get("StartToCloseTimeout"));
-  }
-
-  @ActivityInterface
-  public interface TestActivity {
-
-    @ActivityMethod
-    Map<String, Duration> method1();
-
-    @ActivityMethod
-    Map<String, Duration> method2();
-  }
-
-  private static class ActivityImpl implements TestActivity {
-
-    @Override
-    public Map<String, Duration> method1() {
-      ActivityInfo info = Activity.getExecutionContext().getInfo();
-      Hashtable<String, Duration> result =
-          new Hashtable<String, Duration>() {
-            {
-              put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-              put("StartToCloseTimeout", info.getStartToCloseTimeout());
-            }
-          };
-      return result;
-    }
-
-    @Override
-    public Map<String, Duration> method2() {
-      ActivityInfo info = Activity.getExecutionContext().getInfo();
-      Hashtable<String, Duration> result =
-          new Hashtable<String, Duration>() {
-            {
-              put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
-              put("StartToCloseTimeout", info.getStartToCloseTimeout());
-            }
-          };
-      return result;
-    }
   }
 }

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.activity;
+
+import java.time.Duration;
+import java.util.Map;
+
+@ActivityInterface
+public interface LocalActivityTest {
+
+  @ActivityMethod
+  Map<String, Duration> localActivity1();
+
+  @ActivityMethod
+  Map<String, Duration> localActivity2();
+}

--- a/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTestImpl.java
+++ b/temporal-sdk/src/test/java/io/temporal/activity/LocalActivityTestImpl.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.activity;
+
+import java.time.Duration;
+import java.util.Hashtable;
+import java.util.Map;
+
+public class LocalActivityTestImpl implements LocalActivityTest {
+
+  @Override
+  public Map<String, Duration> localActivity1() {
+    ActivityInfo info = Activity.getExecutionContext().getInfo();
+    Hashtable<String, Duration> result =
+        new Hashtable<String, Duration>() {
+          {
+            put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
+            put("StartToCloseTimeout", info.getStartToCloseTimeout());
+          }
+        };
+    return result;
+  }
+
+  @Override
+  public Map<String, Duration> localActivity2() {
+    ActivityInfo info = Activity.getExecutionContext().getInfo();
+    Hashtable<String, Duration> result =
+        new Hashtable<String, Duration>() {
+          {
+            put("ScheduleToCloseTimeout", info.getScheduleToCloseTimeout());
+            put("StartToCloseTimeout", info.getStartToCloseTimeout());
+          }
+        };
+    return result;
+  }
+}

--- a/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
+++ b/temporal-sdk/src/test/java/io/temporal/workflow/GetCronScheduleFromWorkflowInfoTest.java
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (C) 2020 Temporal Technologies, Inc. All Rights Reserved.
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.workflow;
+
+import static io.temporal.testing.internal.SDKTestOptions.newWorkflowOptionsWithTimeouts;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.temporal.client.WorkflowFailedException;
+import io.temporal.client.WorkflowStub;
+import io.temporal.failure.CanceledFailure;
+import io.temporal.testing.internal.SDKTestWorkflowRule;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class GetCronScheduleFromWorkflowInfoTest {
+
+  @Rule public TestName testName = new TestName();
+
+  @Rule
+  public SDKTestWorkflowRule testWorkflowRule =
+      SDKTestWorkflowRule.newBuilder()
+          .setWorkflowTypes(TestGetCronScheduleWorkflowsFuncImpl.class)
+          .build();
+
+  @Test
+  public void testGetCronScheduleFromWorkflowInfo() throws InterruptedException {
+    Assume.assumeFalse("skipping for docker tests", testWorkflowRule.isUseExternalService());
+
+    WorkflowStub workflowStub =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newUntypedWorkflowStub(
+                "TestGetCronScheduleWorkflowsFunc",
+                newWorkflowOptionsWithTimeouts(testWorkflowRule.getTaskQueue())
+                    .toBuilder()
+                    .setCronSchedule("0 0 * * *")
+                    .build());
+    testWorkflowRule.registerDelayedCallback(Duration.ofDays(1), workflowStub::cancel);
+    workflowStub.start(testName.getMethodName());
+
+    // make sure that the cron workflow was cancelled
+    try {
+      workflowStub.getResult(String.class);
+      fail("unreachable");
+    } catch (WorkflowFailedException e) {
+      assertTrue(e.getCause() instanceof CanceledFailure);
+    }
+
+    // make sure we have the completion results available
+    Map<Integer, String> lastCompletionResults =
+        TestGetCronScheduleWorkflowsFuncImpl.lastCompletionResults.get(testName.getMethodName());
+    assertNotNull(lastCompletionResults);
+    assertTrue(lastCompletionResults.size() > 0);
+    // get the very last run completion result and make sure its the cron
+    assertEquals("0 0 * * *", lastCompletionResults.get(lastCompletionResults.size()));
+  }
+
+  @WorkflowInterface
+  public interface TestGetCronScheduleWorkflowsFunc {
+    @WorkflowMethod
+    String func(String testName);
+  }
+
+  public static class TestGetCronScheduleWorkflowsFuncImpl
+      implements TestGetCronScheduleWorkflowsFunc {
+
+    public static final Map<String, Map<Integer, String>> lastCompletionResults =
+        new ConcurrentHashMap<>();
+    public static final Map<String, AtomicInteger> retryCount = new ConcurrentHashMap<>();
+
+    @Override
+    public String func(String testName) {
+      int count = retryCount.computeIfAbsent(testName, k -> new AtomicInteger()).incrementAndGet();
+      lastCompletionResults
+          .computeIfAbsent(testName, k -> new HashMap<>())
+          .put(count, Workflow.getLastCompletionResult(String.class));
+
+      return Workflow.getInfo().getCronSchedule();
+    }
+  }
+}

--- a/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
+++ b/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsTag.java
@@ -22,6 +22,7 @@ package io.temporal.serviceclient;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.util.ImmutableMap;
 import io.grpc.CallOptions;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -36,6 +37,7 @@ public class MetricsTag {
   public static final String STATUS_CODE = "status_code";
   public static final String EXCEPTION = "exception";
   public static final String OPERATION_NAME = "operation";
+  public static final String WORKER_TYPE = "worker_type";
 
   /** Used to pass metrics scope to the interceptor */
   public static final CallOptions.Key<Scope> METRICS_TAGS_CALL_OPTIONS_KEY =
@@ -49,6 +51,12 @@ public class MetricsTag {
 
   private static final ConcurrentMap<String, Map<String, String>> tagsByNamespace =
       new ConcurrentHashMap<>();
+
+  public interface TagValue {
+    String getTag();
+
+    String getValue();
+  }
 
   /** Returns a set of default metric tags for a given namespace. */
   public static Map<String, String> defaultTags(String namespace) {
@@ -66,6 +74,15 @@ public class MetricsTag {
         .put(STATUS_CODE, DEFAULT_VALUE)
         .put(EXCEPTION, DEFAULT_VALUE)
         .put(WORKFLOW_TYPE, DEFAULT_VALUE)
+        .put(WORKER_TYPE, DEFAULT_VALUE)
         .build();
+  }
+
+  public static Scope tagged(Scope scope, String tagName, String tagValue) {
+    return scope.tagged(Collections.singletonMap(tagName, tagValue));
+  }
+
+  public static Scope tagged(Scope scope, TagValue tagValue) {
+    return tagged(scope, tagValue.getTag(), tagValue.getValue());
   }
 }

--- a/temporal-test-server/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
+++ b/temporal-test-server/src/main/java/io/temporal/internal/sync/DummySyncWorkflowContext.java
@@ -270,5 +270,10 @@ public class DummySyncWorkflowContext {
     public int getAttempt() {
       return 1;
     }
+
+    @Override
+    public String getCronSchedule() {
+      return "dummy-cron-schedule";
+    }
   }
 }

--- a/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
+++ b/temporal-testing/src/main/java/io/temporal/testing/internal/SDKTestOptions.java
@@ -57,6 +57,12 @@ public class SDKTestOptions {
     return ActivityOptions.newBuilder().setScheduleToCloseTimeout(Duration.ofSeconds(20)).build();
   }
 
+  public static LocalActivityOptions newLocalActivityOptions20sScheduleToClose() {
+    return LocalActivityOptions.newBuilder()
+        .setScheduleToCloseTimeout(Duration.ofSeconds(20))
+        .build();
+  }
+
   public static ActivityOptions newActivityOptionsForTaskQueue(String taskQueue) {
     if (DEBUGGER_TIMEOUTS) {
       return ActivityOptions.newBuilder()


### PR DESCRIPTION
Following existing WorkflowImplementationOptions.setActivityOptions, allow user
to define local activity options for different types of activities instead of
defining them in workflow code.